### PR TITLE
Fix paths for bento structure change

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ or [Parallels Desktop](http://www.parallels.com/products/desktop/) (for OS X).
 
   `bundle install`
 
-1. Run `bundle exec ./generate`. This prints to STDOUT the JSON document that is suitable for use by Packer. Save it in `../bento/packer`:
+1. Run `bundle exec ./generate`. This prints to STDOUT the JSON document that is suitable for use by Packer. Save it in `../bento`:
 
-  `bundle exec ./generate > ../bento/packer/ubuntu-12.04-amd64-travis.json`
+  `bundle exec ./generate > ../bento/ubuntu-12.04-amd64-travis.json`
 
-1. Move to `../bento/packer`.
+1. Move to `../bento`.
 1. It seems that in the first packer build, the `system_info` cookbook
    appears to hang.
    It should be removed from the JSON template.

--- a/generate
+++ b/generate
@@ -6,12 +6,12 @@ require 'active_support'
 
 ubuntu_release = ARGV[0] || '12.04'
 
-input_file  = "../bento/packer/ubuntu-#{ubuntu_release}-amd64-travis.json.in"
-output_file = "../bento/packer/ubuntu-#{ubuntu_release}-amd64-travis.json"
+input_file  = "../bento/ubuntu-#{ubuntu_release}-amd64-travis.json.in"
+output_file = "../bento/ubuntu-#{ubuntu_release}-amd64-travis.json"
 
 def modify_preseed(release, string_before, string_after)
-  src  = "../bento/packer/http/ubuntu-#{release}/preseed.cfg"
-  sink = "../bento/packer/http/ubuntu-#{release}/preseed-travis.cfg"
+  src  = "../bento/http/ubuntu-#{release}/preseed.cfg"
+  sink = "../bento/http/ubuntu-#{release}/preseed-travis.cfg"
 
   replace_all(src, sink, "^d-i passwd(.*)#{string_before}$", "d-i passwd\\1#{string_after}")
 end
@@ -35,13 +35,13 @@ end
 
 modify_preseed(ubuntu_release, 'vagrant', 'travis')
 
-replace_all('../bento/packer/scripts/common/vagrant.sh', '../bento/packer/scripts/common/travis.sh', '([ ~])vagrant', '\1travis')
-replace_all('../bento/packer/scripts/common/vmtools.sh', '../bento/packer/scripts/common/vmtools-travis.sh', 'vagrant', 'travis')
+replace_all('../bento/scripts/common/vagrant.sh', '../bento/scripts/common/travis.sh', '([ ~])vagrant', '\1travis')
+replace_all('../bento/scripts/common/vmtools.sh', '../bento/scripts/common/vmtools-travis.sh', 'vagrant', 'travis')
 
 ## Note that transformation is strictly textual.
 ## While the JSON data are structured, the structure is not amenable to changes
 ## required for our use
-replace_all("../bento/packer/ubuntu-#{ubuntu_release}-amd64.json", input_file,
+replace_all("../bento/ubuntu-#{ubuntu_release}-amd64.json", input_file,
   "(get_hostname=|echo '|ssh_(password|username)\": \"|common/)vagrant", '\1travis',           # user name, password and hostname
   "provisionerless",                                                     "latest",             # Chef version
   "vmtools\.sh",                                                         "vmtools-travis.sh",  # VMWare tools file
@@ -58,7 +58,7 @@ yaml_standard = YAML.load_file(File.join(File.dirname(__FILE__), '..', 'travis-c
 
 travis_provisioner = {
   'type'           => 'chef-solo',
-  'cookbook_paths' => [ "../../travis-cookbooks/ci_environment" ],
+  'cookbook_paths' => [ "../travis-cookbooks/ci_environment" ],
   'json'           => ( yaml_common['json']    || {} ).deep_merge( yaml_standard['json']    || {} ).merge({'system_info' => {'cookbooks_sha' => `cd ../travis-cookbooks; git show-ref refs/heads/master -s`.chomp}}),
   'run_list'       => ( yaml_common['recipes'] || [] ).concat(     yaml_standard['recipes'] || [] )
 }

--- a/tests/ubuntu-12.04-amd64-travis.json
+++ b/tests/ubuntu-12.04-amd64-travis.json
@@ -29,10 +29,11 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{ .Version }}.iso",
       "guest_os_type": "Ubuntu_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
       "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/12.04/ubuntu-12.04.5-server-amd64.iso",
+      "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.5-server-amd64.iso",
       "output_directory": "packer-ubuntu-12.04-amd64-virtualbox",
       "shutdown_command": "echo 'travis'|sudo -S shutdown -P now",
       "ssh_password": "travis",
@@ -88,7 +89,7 @@
       "http_directory": "http",
       "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
       "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/12.04/ubuntu-12.04.5-server-amd64.iso",
+      "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.5-server-amd64.iso",
       "output_directory": "packer-ubuntu-12.04-amd64-vmware",
       "shutdown_command": "echo 'travis'|sudo -S shutdown -P now",
       "ssh_password": "travis",
@@ -131,19 +132,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "ubuntu",
       "http_directory": "http",
       "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
       "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/12.04/ubuntu-12.04.5-server-amd64.iso",
+      "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.5-server-amd64.iso",
       "output_directory": "packer-ubuntu-12.04-amd64-parallels",
-      "shutdown_command": "echo 'travis'|sudo -S shutdown -P now",
-      "ssh_password": "travis",
-      "ssh_port": 22,
-      "ssh_username": "travis",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -159,29 +154,40 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'travis'|sudo -S shutdown -P now",
+      "ssh_password": "travis",
+      "ssh_port": 22,
+      "ssh_username": "travis",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-ubuntu-12.04-amd64"
     }
   ],
   "post-processors": [
     {
-      "output": "../builds/{{.Provider}}/travis_ubuntu-12.04_chef-{{user `chef_version`}}.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [
-        "CHEF_VERSION={{user `chef_version`}}"
+
       ],
       "execute_command": "echo 'travis' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
         "scripts/ubuntu/sudoers.sh",
         "scripts/common/travis.sh",
         "scripts/common/vmtools-travis.sh",
-        "scripts/common/chef.sh",
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
@@ -190,7 +196,7 @@
     {
       "type": "chef-solo",
       "cookbook_paths": [
-        "../../travis-cookbooks/ci_environment"
+        "../travis-cookbooks/ci_environment"
       ],
       "json": {
         "rvm": {
@@ -201,26 +207,27 @@
             }
           ],
           "gems": [
-            "bundler",
-            "rake"
+            "nokogiri"
           ]
         },
-        "golang": {
-          "multi": {
-            "versions": [
-              "go1.4"
-            ],
-            "aliases": [
+        "gimme": {
+          "versions": [
+            "1.4.2"
+          ],
+          "default_version": "1.4.2"
+        },
+        "python": {
+          "pyenv": {
+            "pythons": [
 
-            ],
-            "default_version": "go1.4"
+            ]
           }
         },
         "travis_build_environment": {
           "use_tmpfs_for_builds": false
         },
         "system_info": {
-          "cookbooks_sha": "8a96095e8a596bdf51a74360ecc41f9aa27330f6"
+          "cookbooks_sha": "3b53c18b350f030f35dbec021c446c1926008e52"
         }
       },
       "run_list": [
@@ -228,12 +235,15 @@
         "apt",
         "package-updates",
         "build-essential",
+        "ccache",
         "clang::tarball",
-        "golang::multi",
+        "gimme",
+        "wget",
         "networking_basic",
         "openssl",
         "sysctl",
         "git::ppa",
+        "git::lfs",
         "mercurial",
         "bazaar",
         "subversion",
@@ -247,6 +257,7 @@
         "libncurses",
         "libossp-uuid",
         "libffi",
+        "libicu",
         "ragel",
         "imagemagick",
         "mingw32",
@@ -257,8 +268,8 @@
         "sqlite",
         "rvm",
         "rvm::multi",
-        "python",
-        "python::pip",
+        "python::pyenv",
+        "python::system",
         "nodejs::multi",
         "postgresql",
         "redis",
@@ -275,18 +286,29 @@
         "xserver",
         "firefox::tarball",
         "chromium",
+        "google-chrome",
         "phantomjs::tarball",
+        "phantomjs::2.0",
         "emacs::nox",
         "vim",
         "system_info",
         "sweeper",
+        "mysql::client_deb",
+        "mysql::server_deb",
         "mysql::server_on_ramfs",
         "python::devshm"
       ]
     }
   ],
   "variables": {
-    "chef_version": "latest",
-    "mirror": "http://releases.ubuntu.com"
+    "arch": "64",
+    "box_basename": "ubuntu-12.04",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://releases.ubuntu.com",
+    "name": "ubuntu-12.04",
+    "template": "ubuntu-12.04-amd64",
+    "version": "2.0.TIMESTAMP"
   }
 }


### PR DESCRIPTION
chef/bento@ce4cf23 changed the bento project structure by moving the
contents of the former `packer` subdirectory to the root of the project.
Adjust paths accordingly.

Closes #3
